### PR TITLE
test for flatcar beta with kernel configs

### DIFF
--- a/gen-control-usb-root.sh
+++ b/gen-control-usb-root.sh
@@ -7,7 +7,7 @@
 # To update flacar image run this script supplying the verison you want
 # To update the images/efi.img file for some reason pass a valid flatcar version followed by a 1.
 
-FLATCAR_BASE_URL="https://stable.release.flatcar-linux.net/amd64-usr"
+FLATCAR_BASE_URL="https://beta.release.flatcar-linux.net/amd64-usr"
 FLATCAR_VER="${1:-"4230.2.1"}"
 GRUB_INST_CMD="grub-install"
 GPG_KEY="-----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ default:
 version_dirty := `[ -z "$(git status -s)" ] || echo "-$(date +"%H%M%S")"`
 version := `git describe --tags --dirty --always` + version_dirty
 
-flatcar_version := "4230.2.1"
+flatcar_version := "4344.1.1"
 
 # Print version that will be used in the build
 version:


### PR DESCRIPTION
Commit for testing the beta edition of the flatcar. This beta version has the kernel configs for mlx5 driver.